### PR TITLE
Ferries Experiment

### DIFF
--- a/share/sydney-map.json
+++ b/share/sydney-map.json
@@ -72,6 +72,56 @@
         "color": "#e4022d"
       },
       {
+        "id": "F1",
+        "name": "F1",
+        "color": "#00774b"
+      },
+      {
+        "id": "F2",
+        "name": "F2",
+        "color": "#144734"
+      },
+      {
+        "id": "F3",
+        "name": "F3",
+        "color": "#648c3c"
+      },
+      {
+        "id": "F4",
+        "name": "F4",
+        "color": "#bfd730"
+      },
+      {
+        "id": "F5",
+        "name": "F5",
+        "color": "#286142"
+      },
+      {
+        "id": "F6",
+        "name": "F6",
+        "color": "#00ab51"
+      },
+      {
+        "id": "F7",
+        "name": "F7",
+        "color": "#00b189"
+      },
+      {
+        "id": "F8",
+        "name": "F8",
+        "color": "#55622b"
+      },
+      {
+        "id": "F9",
+        "name": "F9",
+        "color": "#65b32e"
+      },
+      {
+        "id": "F10",
+        "name": "F10",
+        "color": "#5ab031"
+      },
+      {
         "id": "Walk1",
         "name": "Walk1",
         "color": "#000000"
@@ -98,7 +148,7 @@
       }
     ]
   },
-  "name": "Sydney Rail Network",
+  "name": "Sydney Public Transport Network",
   "stations": {
     "station": [
       {
@@ -135,7 +185,8 @@
         "id": "L106",
         "name": "Pyrmont Bay",
         "line": "L1",
-        "link": "L105,L107"
+        "link": "L105,L107",
+        "other_link": "Walk:F41"
       },
       {
         "id": "L107",
@@ -501,7 +552,8 @@
         "id": "M114",
         "name": "Barangaroo",
         "line": "M1",
-        "link": "M113,T404"
+        "link": "M113,T404",
+        "other_link": "Walk:F33"
       },
       {
         "id": "M115",
@@ -645,13 +697,15 @@
         "id": "T121",
         "name": "Milsons Point",
         "line": "T1,T9",
-        "link": "T120,T122"
+        "link": "T120,T122",
+        "other_link": "Walk:F31"
       },
       {
         "id": "T122",
         "name": "Wynyard",
         "line": "T1,T2,T3,T8,T9,L2,L3",
-        "link": "T121,T123,T203,L201,L202"
+        "link": "T121,T123,T203,L201,L202",
+        "other_link": "Walk:F33"
       },
       {
         "id": "T123",
@@ -687,7 +741,8 @@
         "id": "T128",
         "name": "Parramatta",
         "line": "T1,T2,T5,Walk5",
-        "link": "T218,T129,L408"
+        "link": "T218,T129,L408",
+        "other_link": "Walk:F316"
       },
       {
         "id": "T129",
@@ -848,8 +903,8 @@
       {
         "id": "T203",
         "name": "Circular Quay",
-        "line": "T2,T3,T8,L2,L3",
-        "link": "T202,T122,L201"
+        "line": "T2,T3,T8,L2,L3,F1,F2,F3,F4,F5,F6,F7,F8,F9",
+        "link": "T202,T122,L201,F1,F2,F31,F35,F51,F61,F71,F91"
       },
       {
         "id": "T204",
@@ -1425,7 +1480,8 @@
         "id": "T904",
         "name": "Meadowbank",
         "line": "T9",
-        "link": "T903,T905"
+        "link": "T903,T905",
+        "other_link": "Walk:F313"
       },
       {
         "id": "T905",
@@ -1480,6 +1536,233 @@
         "name": "Normanhurst",
         "line": "T9",
         "link": "T912,T105"
+      },
+      {
+        "id": "F1",
+        "name": "Manly Wharf",
+        "line": "F1",
+        "link": "T203"
+      },
+      {
+        "id": "F2",
+        "name": "Taronga Zoo",
+        "line": "F2",
+        "link": "T203"
+      },
+      {
+        "id": "F31",
+        "name": "Milsons Point Wharf",
+        "line": "F3,F4",
+        "link": "T203,F32",
+        "other_link": "Walk:T121"
+      },
+      {
+        "id": "F32",
+        "name": "McMahons Point",
+        "line": "F3,F4",
+        "link": "F31,F33,F34"
+      },
+      {
+        "id": "F33",
+        "name": "Barangaroo Wharf",
+        "line": "F3,F4,F10",
+        "link": "F32,F34,F41,F101",
+        "other_link": "Walk:T122,Walk:M114"
+      },
+      {
+        "id": "F101",
+        "name": "Pirrama Park",
+        "line": "F10",
+        "link": "F33,F102"
+      },
+      {
+        "id": "F102",
+        "name": "Blackwattle Bay",
+        "line": "F10",
+        "link": "F101"
+      },
+      {
+        "id": "F34",
+        "name": "Balmain East",
+        "line": "F3,F4",
+        "link": "F32,F33,F35"
+      },
+      {
+        "id": "F41",
+        "name": "Pyrmont Bay Wharf",
+        "line": "F4",
+        "link": "F33",
+        "other_link": "Walk:L106"
+      },
+      {
+        "id": "F35",
+        "name": "Balmain",
+        "line": "F3,F8",
+        "link": "F34,F36,T203"
+      },
+      {
+        "id": "F81",
+        "name": "Birchgrove",
+        "line": "F8",
+        "link": "F35,F82"
+      },
+      {
+        "id": "F82",
+        "name": "Greenwich Point",
+        "line": "F8",
+        "link": "F81,F83"
+      },
+      {
+        "id": "F83",
+        "name": "Woolwich",
+        "line": "F8",
+        "link": "F82,F84"
+      },
+      {
+        "id": "F84",
+        "name": "Cockatoo Island",
+        "line": "F3,F8",
+        "link": "F36,F37,F83"
+      },
+      {
+        "id": "F36",
+        "name": "Balmain West",
+        "line": "F3",
+        "link": "F35,F84"
+      },
+      {
+        "id": "F37",
+        "name": "Drummoyne",
+        "line": "F3",
+        "link": "F84,F38"
+      },
+      {
+        "id": "F38",
+        "name": "Huntleys Point",
+        "line": "F3",
+        "link": "F37,F39"
+      },
+      {
+        "id": "F39",
+        "name": "Chiswick",
+        "line": "F3",
+        "link": "F38,F310"
+      },
+      {
+        "id": "F310",
+        "name": "Abbotsford",
+        "line": "F3",
+        "link": "F39,F311"
+      },
+      {
+        "id": "F311",
+        "name": "Cabarita",
+        "line": "F3",
+        "link": "F310,F312"
+      },
+      {
+        "id": "F312",
+        "name": "Kissing Point",
+        "line": "F3",
+        "link": "F311,F313"
+      },
+      {
+        "id": "F313",
+        "name": "Meadowbank wharf",
+        "line": "F3",
+        "link": "F312,F314",
+        "other_link": "Walk:T904"
+      },
+      {
+        "id": "F314",
+        "name": "Sydney Olympic Park",
+        "line": "F3",
+        "link": "F313,F315"
+      },
+      {
+        "id": "F315",
+        "name": "Rydalmere",
+        "line": "F3",
+        "link": "F314,F316"
+      },
+      {
+        "id": "F316",
+        "name": "Parramatta wharf",
+        "line": "F3",
+        "link": "F315",
+        "other_link": "Walk:T128"
+      },
+      {
+        "id": "F51",
+        "name": "Kirribilli",
+        "line": "F5",
+        "link": "T203,F52,F54"
+      },
+      {
+        "id": "F52",
+        "name": "North Sydney wharf",
+        "line": "F5",
+        "link": "F51,F53"
+      },
+      {
+        "id": "F53",
+        "name": "Neutral Bay",
+        "line": "F5",
+        "link": "F52,F54"
+      },
+      {
+        "id": "F54",
+        "name": "Kurraba Point",
+        "line": "F5",
+        "link": "F53,F51"
+      },
+      {
+        "id": "F61",
+        "name": "Cremorne Point",
+        "line": "F6",
+        "link": "T203,F62"
+      },
+      {
+        "id": "F62",
+        "name": "South Mosman",
+        "line": "F6",
+        "link": "F61,F63"
+      },
+      {
+        "id": "F63",
+        "name": "Old Cremorne",
+        "line": "F6",
+        "link": "F62,F64"
+      },
+      {
+        "id": "F64",
+        "name": "Mosman Bay",
+        "line": "F6",
+        "link": "F63"
+      },
+      {
+        "id": "F71",
+        "name": "Darling Point",
+        "line": "F7",
+        "link": "T203,F72"
+      },
+      {
+        "id": "F72",
+        "name": "Double Bay",
+        "line": "F7",
+        "link": "F71"
+      },
+      {
+        "id": "F91",
+        "name": "Rose Bay",
+        "line": "F9",
+        "link": "T203,F92"
+      },
+      {
+        "id": "F92",
+        "name": "Watsons Bay",
+        "line": "F9",
+        "link": "F91"
       }
     ]
   }

--- a/share/sydney-map.json
+++ b/share/sydney-map.json
@@ -1,25 +1,101 @@
 {
   "lines": {
     "line": [
-      { "id": "T1", "name": "T1", "color": "#f99d1c" },
-      { "id": "T2", "name": "T2", "color": "#0098cd" },
-      { "id": "T3", "name": "T3", "color": "#f37021" },
-      { "id": "T4", "name": "T4", "color": "#005aa3" },
-      { "id": "T5", "name": "T5", "color": "#c4258f" },
-      { "id": "T6", "name": "T6", "color": "#7d3f21" },
-      { "id": "T7", "name": "T7", "color": "#6f818e" },
-      { "id": "T8", "name": "T8", "color": "#00954c" },
-      { "id": "T9", "name": "T9", "color": "#d11f2f" },
-      { "id": "M1", "name": "M1", "color": "#168388" },
-      { "id": "L1", "name": "L1", "color": "#be1622" },
-      { "id": "L2", "name": "L2", "color": "#dd1e25" },
-      { "id": "L3", "name": "L3", "color": "#781140" },
-      { "id": "L4", "name": "L4", "color": "#e4022d" },
-      { "id": "Walk1", "name": "Walk1", "color": "#000000" },
-      { "id": "Walk2", "name": "Walk2", "color": "#000000" },
-      { "id": "Walk3", "name": "Walk3", "color": "#000000" },
-      { "id": "Walk4", "name": "Walk4", "color": "#000000" },
-      { "id": "Walk5", "name": "Walk5", "color": "#000000" }
+      {
+        "id": "T1",
+        "name": "T1",
+        "color": "#f99d1c"
+      },
+      {
+        "id": "T2",
+        "name": "T2",
+        "color": "#0098cd"
+      },
+      {
+        "id": "T3",
+        "name": "T3",
+        "color": "#f37021"
+      },
+      {
+        "id": "T4",
+        "name": "T4",
+        "color": "#005aa3"
+      },
+      {
+        "id": "T5",
+        "name": "T5",
+        "color": "#c4258f"
+      },
+      {
+        "id": "T6",
+        "name": "T6",
+        "color": "#7d3f21"
+      },
+      {
+        "id": "T7",
+        "name": "T7",
+        "color": "#6f818e"
+      },
+      {
+        "id": "T8",
+        "name": "T8",
+        "color": "#00954c"
+      },
+      {
+        "id": "T9",
+        "name": "T9",
+        "color": "#d11f2f"
+      },
+      {
+        "id": "M1",
+        "name": "M1",
+        "color": "#168388"
+      },
+      {
+        "id": "L1",
+        "name": "L1",
+        "color": "#be1622"
+      },
+      {
+        "id": "L2",
+        "name": "L2",
+        "color": "#dd1e25"
+      },
+      {
+        "id": "L3",
+        "name": "L3",
+        "color": "#781140"
+      },
+      {
+        "id": "L4",
+        "name": "L4",
+        "color": "#e4022d"
+      },
+      {
+        "id": "Walk1",
+        "name": "Walk1",
+        "color": "#000000"
+      },
+      {
+        "id": "Walk2",
+        "name": "Walk2",
+        "color": "#000000"
+      },
+      {
+        "id": "Walk3",
+        "name": "Walk3",
+        "color": "#000000"
+      },
+      {
+        "id": "Walk4",
+        "name": "Walk4",
+        "color": "#000000"
+      },
+      {
+        "id": "Walk5",
+        "name": "Walk5",
+        "color": "#000000"
+      }
     ]
   },
   "name": "Sydney Rail Network",
@@ -61,7 +137,12 @@
         "line": "L1",
         "link": "L105,L107"
       },
-      { "id": "L107", "name": "The Star", "line": "L1", "link": "L106,L108" },
+      {
+        "id": "L107",
+        "name": "The Star",
+        "line": "L1",
+        "link": "L106,L108"
+      },
       {
         "id": "L108",
         "name": "John Street Square",
@@ -80,7 +161,12 @@
         "line": "L1",
         "link": "L109,L111"
       },
-      { "id": "L111", "name": "Glebe", "line": "L1", "link": "L110,L112" },
+      {
+        "id": "L111",
+        "name": "Glebe",
+        "line": "L1",
+        "link": "L110,L112"
+      },
       {
         "id": "L112",
         "name": "Jubilee Park",
@@ -93,15 +179,30 @@
         "line": "L1",
         "link": "L112,L114"
       },
-      { "id": "L114", "name": "Lilyfield", "line": "L1", "link": "L113,L115" },
+      {
+        "id": "L114",
+        "name": "Lilyfield",
+        "line": "L1",
+        "link": "L113,L115"
+      },
       {
         "id": "L115",
         "name": "Leichhardt North",
         "line": "L1",
         "link": "L114,L116"
       },
-      { "id": "L116", "name": "Hawthorne", "line": "L1", "link": "L115,L117" },
-      { "id": "L117", "name": "Marion", "line": "L1", "link": "L116,L118" },
+      {
+        "id": "L116",
+        "name": "Hawthorne",
+        "line": "L1",
+        "link": "L115,L117"
+      },
+      {
+        "id": "L117",
+        "name": "Marion",
+        "line": "L1",
+        "link": "L116,L118"
+      },
       {
         "id": "L118",
         "name": "Taverners Hill",
@@ -120,7 +221,12 @@
         "line": "L1",
         "link": "L119,L121"
       },
-      { "id": "L121", "name": "Arlington", "line": "L1", "link": "L120,L122" },
+      {
+        "id": "L121",
+        "name": "Arlington",
+        "line": "L1",
+        "link": "L120,L122"
+      },
       {
         "id": "L122",
         "name": "Dulwich Grove",
@@ -133,7 +239,12 @@
         "line": "L2,L3",
         "link": "T203,T122"
       },
-      { "id": "L202", "name": "QVB", "line": "L2,L3", "link": "T122,T123" },
+      {
+        "id": "L202",
+        "name": "QVB",
+        "line": "L2,L3",
+        "link": "T122,T123"
+      },
       {
         "id": "L203",
         "name": "Chinatown",
@@ -182,16 +293,36 @@
         "line": "L2",
         "link": "L209,L211"
       },
-      { "id": "L211", "name": "Randwick", "line": "L2", "link": "L210" },
-      { "id": "L301", "name": "ES Marks", "line": "L3", "link": "L207,L302" },
-      { "id": "L302", "name": "Kensington", "line": "L3", "link": "L301,L303" },
+      {
+        "id": "L211",
+        "name": "Randwick",
+        "line": "L2",
+        "link": "L210"
+      },
+      {
+        "id": "L301",
+        "name": "ES Marks",
+        "line": "L3",
+        "link": "L207,L302"
+      },
+      {
+        "id": "L302",
+        "name": "Kensington",
+        "line": "L3",
+        "link": "L301,L303"
+      },
       {
         "id": "L303",
         "name": "UNSW Anzac Parade",
         "line": "L3",
         "link": "L302,L304"
       },
-      { "id": "L304", "name": "Kingsford", "line": "L3", "link": "L303,L305" },
+      {
+        "id": "L304",
+        "name": "Kingsford",
+        "line": "L3",
+        "link": "L303,L305"
+      },
       {
         "id": "L305",
         "name": "Juniors Kingsford",
@@ -210,7 +341,12 @@
         "line": "L4",
         "link": "L401,L403"
       },
-      { "id": "L403", "name": "Ngara", "line": "L4", "link": "L402,L404" },
+      {
+        "id": "L403",
+        "name": "Ngara",
+        "line": "L4",
+        "link": "L402,L404"
+      },
       {
         "id": "L404",
         "name": "Benaud Oval",
@@ -259,20 +395,60 @@
         "line": "L4",
         "link": "L410,L412"
       },
-      { "id": "L412", "name": "Yallamundi", "line": "L4", "link": "L411,L413" },
-      { "id": "L413", "name": "Dundas", "line": "L4", "link": "L412,L414" },
-      { "id": "L414", "name": "Telopea", "line": "L4", "link": "L413,L415" },
-      { "id": "L415", "name": "Carlingford", "line": "L4", "link": "L414" },
-      { "id": "M101", "name": "Tallawong", "line": "M1", "link": "M102" },
-      { "id": "M102", "name": "Rouse Hill", "line": "M1", "link": "M101,M103" },
-      { "id": "M103", "name": "Kellyville", "line": "M1", "link": "M102,M104" },
+      {
+        "id": "L412",
+        "name": "Yallamundi",
+        "line": "L4",
+        "link": "L411,L413"
+      },
+      {
+        "id": "L413",
+        "name": "Dundas",
+        "line": "L4",
+        "link": "L412,L414"
+      },
+      {
+        "id": "L414",
+        "name": "Telopea",
+        "line": "L4",
+        "link": "L413,L415"
+      },
+      {
+        "id": "L415",
+        "name": "Carlingford",
+        "line": "L4",
+        "link": "L414"
+      },
+      {
+        "id": "M101",
+        "name": "Tallawong",
+        "line": "M1",
+        "link": "M102"
+      },
+      {
+        "id": "M102",
+        "name": "Rouse Hill",
+        "line": "M1",
+        "link": "M101,M103"
+      },
+      {
+        "id": "M103",
+        "name": "Kellyville",
+        "line": "M1",
+        "link": "M102,M104"
+      },
       {
         "id": "M104",
         "name": "Bella Vista",
         "line": "M1",
         "link": "M103,M105"
       },
-      { "id": "M105", "name": "Norwest", "line": "M1", "link": "M104,M106" },
+      {
+        "id": "M105",
+        "name": "Norwest",
+        "line": "M1",
+        "link": "M104,M106"
+      },
       {
         "id": "M106",
         "name": "Hills Showground",
@@ -303,19 +479,54 @@
         "line": "M1",
         "link": "M109,M111"
       },
-      { "id": "M111", "name": "North Ryde", "line": "M1", "link": "M110,T115" },
-      { "id": "M112", "name": "Crows Nest", "line": "M1", "link": "T115,M113" },
+      {
+        "id": "M111",
+        "name": "North Ryde",
+        "line": "M1",
+        "link": "M110,T115"
+      },
+      {
+        "id": "M112",
+        "name": "Crows Nest",
+        "line": "M1",
+        "link": "T115,M113"
+      },
       {
         "id": "M113",
         "name": "Victoria Cross",
         "line": "M1",
         "link": "M112,M114"
       },
-      { "id": "M114", "name": "Barangaroo", "line": "M1", "link": "M113,T404" },
-      { "id": "M115", "name": "Gadigal", "line": "M1", "link": "T404,T124" },
-      { "id": "M116", "name": "Waterloo", "line": "M1", "link": "T124,T405" },
-      { "id": "M118", "name": "Dulwich Hill", "line": "L1", "link": "L122" },
-      { "id": "T101", "name": "Berowra", "line": "T1", "link": "T102" },
+      {
+        "id": "M114",
+        "name": "Barangaroo",
+        "line": "M1",
+        "link": "M113,T404"
+      },
+      {
+        "id": "M115",
+        "name": "Gadigal",
+        "line": "M1",
+        "link": "T404,T124"
+      },
+      {
+        "id": "M116",
+        "name": "Waterloo",
+        "line": "M1",
+        "link": "T124,T405"
+      },
+      {
+        "id": "M118",
+        "name": "Dulwich Hill",
+        "line": "L1",
+        "link": "L122"
+      },
+      {
+        "id": "T101",
+        "name": "Berowra",
+        "line": "T1",
+        "link": "T102"
+      },
       {
         "id": "T102",
         "name": "Mount Kuring-gai",
@@ -328,20 +539,60 @@
         "line": "T1",
         "link": "T102,T104"
       },
-      { "id": "T104", "name": "Asquith", "line": "T1", "link": "T103,T105" },
+      {
+        "id": "T104",
+        "name": "Asquith",
+        "line": "T1",
+        "link": "T103,T105"
+      },
       {
         "id": "T105",
         "name": "Hornsby",
         "line": "T1,T9",
         "link": "T104,T106,T913"
       },
-      { "id": "T106", "name": "Waitara", "line": "T1", "link": "T105,T107" },
-      { "id": "T107", "name": "Wahroonga", "line": "T1", "link": "T106,T108" },
-      { "id": "T108", "name": "Warrawee", "line": "T1", "link": "T107,T109" },
-      { "id": "T109", "name": "Turramurra", "line": "T1", "link": "T108,T110" },
-      { "id": "T110", "name": "Pymble", "line": "T1", "link": "T109,T111" },
-      { "id": "T111", "name": "Gordon", "line": "T1,T9", "link": "T110,T112" },
-      { "id": "T112", "name": "Killara", "line": "T1,T9", "link": "T111,T113" },
+      {
+        "id": "T106",
+        "name": "Waitara",
+        "line": "T1",
+        "link": "T105,T107"
+      },
+      {
+        "id": "T107",
+        "name": "Wahroonga",
+        "line": "T1",
+        "link": "T106,T108"
+      },
+      {
+        "id": "T108",
+        "name": "Warrawee",
+        "line": "T1",
+        "link": "T107,T109"
+      },
+      {
+        "id": "T109",
+        "name": "Turramurra",
+        "line": "T1",
+        "link": "T108,T110"
+      },
+      {
+        "id": "T110",
+        "name": "Pymble",
+        "line": "T1",
+        "link": "T109,T111"
+      },
+      {
+        "id": "T111",
+        "name": "Gordon",
+        "line": "T1,T9",
+        "link": "T110,T112"
+      },
+      {
+        "id": "T112",
+        "name": "Killara",
+        "line": "T1,T9",
+        "link": "T111,T113"
+      },
       {
         "id": "T113",
         "name": "Lindfield",
@@ -474,19 +725,54 @@
         "line": "T1,T5",
         "link": "T133,T135,T143"
       },
-      { "id": "T135", "name": "Doonside", "line": "T1", "link": "T134,T136" },
-      { "id": "T136", "name": "Rooty Hill", "line": "T1", "link": "T135,T137" },
+      {
+        "id": "T135",
+        "name": "Doonside",
+        "line": "T1",
+        "link": "T134,T136"
+      },
+      {
+        "id": "T136",
+        "name": "Rooty Hill",
+        "line": "T1",
+        "link": "T135,T137"
+      },
       {
         "id": "T137",
         "name": "Mount Druitt",
         "line": "T1",
         "link": "T136,T138"
       },
-      { "id": "T138", "name": "St Marys", "line": "T1", "link": "T137,T139" },
-      { "id": "T139", "name": "Werrington", "line": "T1", "link": "T138,T140" },
-      { "id": "T140", "name": "Kingswood", "line": "T1", "link": "T139,T141" },
-      { "id": "T141", "name": "Penrith", "line": "T1", "link": "T140,T142" },
-      { "id": "T142", "name": "Emu Plains", "line": "T1", "link": "T141" },
+      {
+        "id": "T138",
+        "name": "St Marys",
+        "line": "T1",
+        "link": "T137,T139"
+      },
+      {
+        "id": "T139",
+        "name": "Werrington",
+        "line": "T1",
+        "link": "T138,T140"
+      },
+      {
+        "id": "T140",
+        "name": "Kingswood",
+        "line": "T1",
+        "link": "T139,T141"
+      },
+      {
+        "id": "T141",
+        "name": "Penrith",
+        "line": "T1",
+        "link": "T140,T142"
+      },
+      {
+        "id": "T142",
+        "name": "Emu Plains",
+        "line": "T1",
+        "link": "T141"
+      },
       {
         "id": "T143",
         "name": "Marayong",
@@ -523,7 +809,12 @@
         "line": "T1,T5",
         "link": "T147,T149"
       },
-      { "id": "T149", "name": "Windsor", "line": "T1,T5", "link": "T148,T150" },
+      {
+        "id": "T149",
+        "name": "Windsor",
+        "line": "T1,T5",
+        "link": "T148,T150"
+      },
       {
         "id": "T150",
         "name": "Clarendon",
@@ -536,7 +827,12 @@
         "line": "T1,T5",
         "link": "T150,T152"
       },
-      { "id": "T152", "name": "Richmond", "line": "T1,T5", "link": "T151" },
+      {
+        "id": "T152",
+        "name": "Richmond",
+        "line": "T1,T5",
+        "link": "T151"
+      },
       {
         "id": "T201",
         "name": "Museum",
@@ -561,7 +857,12 @@
         "line": "T2,T3",
         "link": "T125,T205"
       },
-      { "id": "T205", "name": "Newtown", "line": "T2,T3", "link": "T204,T206" },
+      {
+        "id": "T205",
+        "name": "Newtown",
+        "line": "T2,T3",
+        "link": "T204,T206"
+      },
       {
         "id": "T206",
         "name": "Stanmore",
@@ -592,7 +893,12 @@
         "line": "T2,T3",
         "link": "T209,T211"
       },
-      { "id": "T211", "name": "Croydon", "line": "T2,T3", "link": "T210,T212" },
+      {
+        "id": "T211",
+        "name": "Croydon",
+        "line": "T2,T3",
+        "link": "T210,T212"
+      },
       {
         "id": "T212",
         "name": "Burwood",
@@ -611,8 +917,18 @@
         "line": "T2,T3",
         "link": "T213,T127"
       },
-      { "id": "T215", "name": "Auburn", "line": "T1,T2", "link": "T127,T216" },
-      { "id": "T216", "name": "Clyde", "line": "T1,T2", "link": "T215,T217" },
+      {
+        "id": "T215",
+        "name": "Auburn",
+        "line": "T1,T2",
+        "link": "T127,T216"
+      },
+      {
+        "id": "T216",
+        "name": "Clyde",
+        "line": "T1,T2",
+        "link": "T215,T217"
+      },
       {
         "id": "T217",
         "name": "Granville",
@@ -637,7 +953,12 @@
         "line": "T2,T5",
         "link": "T219,T221"
       },
-      { "id": "T221", "name": "Yennora", "line": "T2,T5", "link": "T220,T222" },
+      {
+        "id": "T221",
+        "name": "Yennora",
+        "line": "T2,T5",
+        "link": "T220,T222"
+      },
       {
         "id": "T222",
         "name": "Fairfield",
@@ -668,7 +989,12 @@
         "line": "T2,T3,T5",
         "link": "T225,T227"
       },
-      { "id": "T227", "name": "Casula", "line": "T2,T5", "link": "T226,T228" },
+      {
+        "id": "T227",
+        "name": "Casula",
+        "line": "T2,T5",
+        "link": "T226,T228"
+      },
       {
         "id": "T228",
         "name": "Glenfield",
@@ -681,15 +1007,30 @@
         "line": "T2,T5",
         "link": "T228,T230"
       },
-      { "id": "T230", "name": "Leppington", "line": "T2,T5", "link": "T229" },
-      { "id": "T301", "name": "Berala", "line": "T3,T6", "link": "T127,T302" },
+      {
+        "id": "T230",
+        "name": "Leppington",
+        "line": "T2,T5",
+        "link": "T229"
+      },
+      {
+        "id": "T301",
+        "name": "Berala",
+        "line": "T3,T6",
+        "link": "T127,T302"
+      },
       {
         "id": "T302",
         "name": "Regents Park",
         "line": "T3,T6",
         "link": "T301,T303,T603"
       },
-      { "id": "T303", "name": "Sefton", "line": "T3", "link": "T302,T304" },
+      {
+        "id": "T303",
+        "name": "Sefton",
+        "line": "T3",
+        "link": "T302,T304"
+      },
       {
         "id": "T304",
         "name": "Chester Hill",
@@ -714,8 +1055,18 @@
         "line": "T3",
         "link": "T306,T224"
       },
-      { "id": "T401", "name": "Bondi Junction", "line": "T4", "link": "T402" },
-      { "id": "T402", "name": "Edgecliff", "line": "T4", "link": "T401,T403" },
+      {
+        "id": "T401",
+        "name": "Bondi Junction",
+        "line": "T4",
+        "link": "T402"
+      },
+      {
+        "id": "T402",
+        "name": "Edgecliff",
+        "line": "T4",
+        "link": "T401,T403"
+      },
       {
         "id": "T403",
         "name": "Kings Cross",
@@ -734,59 +1085,204 @@
         "line": "T4,T8,M1",
         "link": "T125,T406,T802,T807,M116"
       },
-      { "id": "T406", "name": "Tempe", "line": "T4", "link": "T405,T407" },
+      {
+        "id": "T406",
+        "name": "Tempe",
+        "line": "T4",
+        "link": "T405,T407"
+      },
       {
         "id": "T407",
         "name": "Wolli Creek",
         "line": "T4,T8",
         "link": "T406,T408,T806,T807"
       },
-      { "id": "T408", "name": "Arncliffe", "line": "T4", "link": "T407,T409" },
-      { "id": "T409", "name": "Banksia", "line": "T4", "link": "T408,T410" },
-      { "id": "T410", "name": "Rockdale", "line": "T4", "link": "T409,T411" },
-      { "id": "T411", "name": "Kogarah", "line": "T4", "link": "T410,T412" },
-      { "id": "T412", "name": "Carlton", "line": "T4", "link": "T411,T413" },
-      { "id": "T413", "name": "Allawah", "line": "T4", "link": "T412,T414" },
-      { "id": "T414", "name": "Hurstville", "line": "T4", "link": "T413,T415" },
-      { "id": "T415", "name": "Penshurst", "line": "T4", "link": "T414,T416" },
-      { "id": "T416", "name": "Mortdale", "line": "T4", "link": "T415,T417" },
-      { "id": "T417", "name": "Oatley", "line": "T4", "link": "T416,T418" },
-      { "id": "T418", "name": "Como", "line": "T4", "link": "T417,T419" },
-      { "id": "T419", "name": "Jannali", "line": "T4", "link": "T418,T420" },
+      {
+        "id": "T408",
+        "name": "Arncliffe",
+        "line": "T4",
+        "link": "T407,T409"
+      },
+      {
+        "id": "T409",
+        "name": "Banksia",
+        "line": "T4",
+        "link": "T408,T410"
+      },
+      {
+        "id": "T410",
+        "name": "Rockdale",
+        "line": "T4",
+        "link": "T409,T411"
+      },
+      {
+        "id": "T411",
+        "name": "Kogarah",
+        "line": "T4",
+        "link": "T410,T412"
+      },
+      {
+        "id": "T412",
+        "name": "Carlton",
+        "line": "T4",
+        "link": "T411,T413"
+      },
+      {
+        "id": "T413",
+        "name": "Allawah",
+        "line": "T4",
+        "link": "T412,T414"
+      },
+      {
+        "id": "T414",
+        "name": "Hurstville",
+        "line": "T4",
+        "link": "T413,T415"
+      },
+      {
+        "id": "T415",
+        "name": "Penshurst",
+        "line": "T4",
+        "link": "T414,T416"
+      },
+      {
+        "id": "T416",
+        "name": "Mortdale",
+        "line": "T4",
+        "link": "T415,T417"
+      },
+      {
+        "id": "T417",
+        "name": "Oatley",
+        "line": "T4",
+        "link": "T416,T418"
+      },
+      {
+        "id": "T418",
+        "name": "Como",
+        "line": "T4",
+        "link": "T417,T419"
+      },
+      {
+        "id": "T419",
+        "name": "Jannali",
+        "line": "T4",
+        "link": "T418,T420"
+      },
       {
         "id": "T420",
         "name": "Sutherland",
         "line": "T4",
         "link": "T419,T421,T425"
       },
-      { "id": "T421", "name": "Loftus", "line": "T4", "link": "T420,T422" },
-      { "id": "T422", "name": "Engadine", "line": "T4", "link": "T421,T423" },
-      { "id": "T423", "name": "Heathcote", "line": "T4", "link": "T422,T424" },
-      { "id": "T424", "name": "Waterfall", "line": "T4", "link": "T423" },
-      { "id": "T425", "name": "Kirrawee", "line": "T4", "link": "T420,T426" },
-      { "id": "T426", "name": "Gymea", "line": "T4", "link": "T425,T427" },
-      { "id": "T427", "name": "Miranda", "line": "T4", "link": "T426,T428" },
-      { "id": "T428", "name": "Caringbah", "line": "T4", "link": "T427,T429" },
-      { "id": "T429", "name": "Woolooware", "line": "T4", "link": "T428,T430" },
-      { "id": "T430", "name": "Cronulla", "line": "T4", "link": "T429" },
-      { "id": "T601", "name": "Bankstown", "line": "T6", "link": "T602" },
-      { "id": "T602", "name": "Yagoona", "line": "T6", "link": "T601,T603" },
-      { "id": "T603", "name": "Birrong", "line": "T6", "link": "T602,T302" },
-      { "id": "T701", "name": "Olympic Park", "line": "T7", "link": "T127" },
+      {
+        "id": "T421",
+        "name": "Loftus",
+        "line": "T4",
+        "link": "T420,T422"
+      },
+      {
+        "id": "T422",
+        "name": "Engadine",
+        "line": "T4",
+        "link": "T421,T423"
+      },
+      {
+        "id": "T423",
+        "name": "Heathcote",
+        "line": "T4",
+        "link": "T422,T424"
+      },
+      {
+        "id": "T424",
+        "name": "Waterfall",
+        "line": "T4",
+        "link": "T423"
+      },
+      {
+        "id": "T425",
+        "name": "Kirrawee",
+        "line": "T4",
+        "link": "T420,T426"
+      },
+      {
+        "id": "T426",
+        "name": "Gymea",
+        "line": "T4",
+        "link": "T425,T427"
+      },
+      {
+        "id": "T427",
+        "name": "Miranda",
+        "line": "T4",
+        "link": "T426,T428"
+      },
+      {
+        "id": "T428",
+        "name": "Caringbah",
+        "line": "T4",
+        "link": "T427,T429"
+      },
+      {
+        "id": "T429",
+        "name": "Woolooware",
+        "line": "T4",
+        "link": "T428,T430"
+      },
+      {
+        "id": "T430",
+        "name": "Cronulla",
+        "line": "T4",
+        "link": "T429"
+      },
+      {
+        "id": "T601",
+        "name": "Bankstown",
+        "line": "T6",
+        "link": "T602"
+      },
+      {
+        "id": "T602",
+        "name": "Yagoona",
+        "line": "T6",
+        "link": "T601,T603"
+      },
+      {
+        "id": "T603",
+        "name": "Birrong",
+        "line": "T6",
+        "link": "T602,T302"
+      },
+      {
+        "id": "T701",
+        "name": "Olympic Park",
+        "line": "T7",
+        "link": "T127"
+      },
       {
         "id": "T801",
         "name": "Erskineville",
         "line": "T8",
         "link": "T125,T802"
       },
-      { "id": "T802", "name": "St Peters", "line": "T8", "link": "T801,T405" },
+      {
+        "id": "T802",
+        "name": "St Peters",
+        "line": "T8",
+        "link": "T801,T405"
+      },
       {
         "id": "T803",
         "name": "Green Square",
         "line": "T8",
         "link": "T124,T804"
       },
-      { "id": "T804", "name": "Mascot", "line": "T8", "link": "T803,T805" },
+      {
+        "id": "T804",
+        "name": "Mascot",
+        "line": "T8",
+        "link": "T803,T805"
+      },
       {
         "id": "T805",
         "name": "Domestic Airport",
@@ -817,36 +1313,96 @@
         "line": "T8",
         "link": "T808,T810"
       },
-      { "id": "T810", "name": "Kingsgrove", "line": "T8", "link": "T809,T811" },
+      {
+        "id": "T810",
+        "name": "Kingsgrove",
+        "line": "T8",
+        "link": "T809,T811"
+      },
       {
         "id": "T811",
         "name": "Beverly Hills",
         "line": "T8",
         "link": "T810,T812"
       },
-      { "id": "T812", "name": "Narwee", "line": "T8", "link": "T811,T813" },
-      { "id": "T813", "name": "Riverwood", "line": "T8", "link": "T812,T814" },
-      { "id": "T814", "name": "Padstow", "line": "T8", "link": "T813,T815" },
-      { "id": "T815", "name": "Revesby", "line": "T8", "link": "T814,T816" },
-      { "id": "T816", "name": "Panania", "line": "T8", "link": "T815,T817" },
-      { "id": "T817", "name": "East Hills", "line": "T8", "link": "T816,T818" },
-      { "id": "T818", "name": "Holsworthy", "line": "T8", "link": "T817,T228" },
+      {
+        "id": "T812",
+        "name": "Narwee",
+        "line": "T8",
+        "link": "T811,T813"
+      },
+      {
+        "id": "T813",
+        "name": "Riverwood",
+        "line": "T8",
+        "link": "T812,T814"
+      },
+      {
+        "id": "T814",
+        "name": "Padstow",
+        "line": "T8",
+        "link": "T813,T815"
+      },
+      {
+        "id": "T815",
+        "name": "Revesby",
+        "line": "T8",
+        "link": "T814,T816"
+      },
+      {
+        "id": "T816",
+        "name": "Panania",
+        "line": "T8",
+        "link": "T815,T817"
+      },
+      {
+        "id": "T817",
+        "name": "East Hills",
+        "line": "T8",
+        "link": "T816,T818"
+      },
+      {
+        "id": "T818",
+        "name": "Holsworthy",
+        "line": "T8",
+        "link": "T817,T228"
+      },
       {
         "id": "T819",
         "name": "Macquarie Fields",
         "line": "T8",
         "link": "T228,T820"
       },
-      { "id": "T820", "name": "Ingleburn", "line": "T8", "link": "T819,T821" },
-      { "id": "T821", "name": "Minto", "line": "T8", "link": "T820,T822" },
-      { "id": "T822", "name": "Leumeah", "line": "T8", "link": "T821,T823" },
+      {
+        "id": "T820",
+        "name": "Ingleburn",
+        "line": "T8",
+        "link": "T819,T821"
+      },
+      {
+        "id": "T821",
+        "name": "Minto",
+        "line": "T8",
+        "link": "T820,T822"
+      },
+      {
+        "id": "T822",
+        "name": "Leumeah",
+        "line": "T8",
+        "link": "T821,T823"
+      },
       {
         "id": "T823",
         "name": "Campbelltown",
         "line": "T8",
         "link": "T822,T824"
       },
-      { "id": "T824", "name": "Macarthur", "line": "T8", "link": "T823" },
+      {
+        "id": "T824",
+        "name": "Macarthur",
+        "line": "T8",
+        "link": "T823"
+      },
       {
         "id": "T901",
         "name": "North Strathfield",
@@ -859,27 +1415,72 @@
         "line": "T9",
         "link": "T901,T903"
       },
-      { "id": "T903", "name": "Rhodes", "line": "T9", "link": "T902,T904" },
-      { "id": "T904", "name": "Meadowbank", "line": "T9", "link": "T903,T905" },
-      { "id": "T905", "name": "West Ryde", "line": "T9", "link": "T904,T906" },
-      { "id": "T906", "name": "Denistone", "line": "T9", "link": "T905,T907" },
-      { "id": "T907", "name": "Eastwood", "line": "T9", "link": "T906,T908" },
+      {
+        "id": "T903",
+        "name": "Rhodes",
+        "line": "T9",
+        "link": "T902,T904"
+      },
+      {
+        "id": "T904",
+        "name": "Meadowbank",
+        "line": "T9",
+        "link": "T903,T905"
+      },
+      {
+        "id": "T905",
+        "name": "West Ryde",
+        "line": "T9",
+        "link": "T904,T906"
+      },
+      {
+        "id": "T906",
+        "name": "Denistone",
+        "line": "T9",
+        "link": "T905,T907"
+      },
+      {
+        "id": "T907",
+        "name": "Eastwood",
+        "line": "T9",
+        "link": "T906,T908"
+      },
       {
         "id": "T908",
         "name": "Epping",
         "line": "T9,M1",
         "link": "T907,T909,M108,M109"
       },
-      { "id": "T909", "name": "Cheltenham", "line": "T9", "link": "T908,T910" },
-      { "id": "T910", "name": "Beecroft", "line": "T9", "link": "T909,T911" },
+      {
+        "id": "T909",
+        "name": "Cheltenham",
+        "line": "T9",
+        "link": "T908,T910"
+      },
+      {
+        "id": "T910",
+        "name": "Beecroft",
+        "line": "T9",
+        "link": "T909,T911"
+      },
       {
         "id": "T911",
         "name": "Pennant Hills",
         "line": "T9",
         "link": "T910,T912"
       },
-      { "id": "T912", "name": "Thornleigh", "line": "T9", "link": "T911,T913" },
-      { "id": "T913", "name": "Normanhurst", "line": "T9", "link": "T912,T105" }
+      {
+        "id": "T912",
+        "name": "Thornleigh",
+        "line": "T9",
+        "link": "T911,T913"
+      },
+      {
+        "id": "T913",
+        "name": "Normanhurst",
+        "line": "T9",
+        "link": "T912,T105"
+      }
     ]
   }
 }

--- a/t/map-tube-sydney.t
+++ b/t/map-tube-sydney.t
@@ -28,7 +28,7 @@ Route 9|Clyde|Guildford|Clyde,Granville,Merrylands,Guildford
 Route 10|Central|Macdonaldtown|Central,Redfern,Macdonaldtown
 Route 11|Central|Burwood|Central,Redfern,Burwood
 Route 12|Central|Strathfield|Central,Redfern,Strathfield
-Route 13|North Sydney|Circular Quay|North Sydney,Milsons Point,Wynyard,Circular Quay
+Route 13|North Sydney|Circular Quay|North Sydney,Milsons Point,Milsons Point Wharf,Circular Quay
 Route 14|UNSW High Street|UNSW Anzac Parade|UNSW High Street,Wansey Road,Royal Randwick,Moore Park,ES Marks,Kensington,UNSW Anzac Parade
 Route 15|Paddy's Markets|Town Hall|Paddy's Markets,Capitol Square,Chinatown,Town Hall
 Route 16|Harris Park|Westmead Hospital|Harris Park,Parramatta,Westmead,Westmead Hospital
@@ -41,3 +41,5 @@ Route 22|East Hills|Villawood|East Hills,Holsworthy,Glenfield,Casula,Liverpool,W
 Route 23|Bankstown|Villawood|Bankstown,Yagoona,Birrong,Regents Park,Sefton,Chester Hill,Leightonfield,Villawood
 Route 24|Town Hall|Museum|Town Hall,Central,Museum
 Route 25|QVB|Haymarket|QVB,Town Hall,Chinatown,Haymarket
+Route F3|Balmain West|Parramatta Wharf|Balmain West,Cockatoo Island,Drummoyne,Huntleys Point,Chiswick,Abbotsford,Cabarita,Kissing Point,Meadowbank Wharf,Sydney Olympic Park,Rydalmere,Parramatta Wharf
+Route F6|Mosman Bay|Circular Quay|Mosman Bay,Old Cremorne,South Mosman,Cremorne Point,Circular Quay


### PR DESCRIPTION
This is just an experiment with adding ferries.

The results are interesting.

I added walking links for locations where walking between the station and the wharf seemed feasible. 

Excluded North Sydney with a walk time of 20+mins. Olympic Park Station and wharf with a walk time of 40+mins.

Parramatta is rated at ~11mins but in my experience it's not practical, however I left it in at <15mins. Meadowbank is ok from personal experience. Milsons point seems ok from google maps at 10mins.

I didnt go in to .pm files at this point, just the json and unit tests for discussion.